### PR TITLE
修复「>^」显示为「LCtrl」的问题

### DIFF
--- a/ui-helper/src/components/dataui/History.vue
+++ b/ui-helper/src/components/dataui/History.vue
@@ -176,7 +176,7 @@ function getKeyDesc(keyName, contentText) {
     .replace(/<!/g, 'LAlt ')
     .replace(/>!/g, 'RAlt ')
     .replace(/<\^/g, 'LCtrl ')
-    .replace(/>\^/g, 'LCtrl ')
+    .replace(/>\^/g, 'RCtrl ')
     .replace(/<#/g, 'LWin ')
     .replace(/>#/g, 'RWin ')
 }


### PR DESCRIPTION
与 #1 有关。

> 4. RCtrl 显示错误，数据统计组合键列表 RCtrl 显示为 LCtrl。